### PR TITLE
Update scuttlebutt@~5.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "email": "raynos2@gmail.com"
   },
   "dependencies": {
-    "scuttlebutt": "~5.3.2",
+    "scuttlebutt": "~5.5",
     "xtend": "~1.0.3",
     "lru-cache": "~2.2.1"
   },


### PR DESCRIPTION
updating to scuttlebutt 5.5 will enable memory management in level-scuttlebutt,
doing so with a slightly open range (~...) will mean I will not have to issue a PR for small scuttlebutt patches!)
If you merge this, I will provide this in the new scuttlebutt service.
